### PR TITLE
fix: skip validating friends if self profile ID

### DIFF
--- a/internal/service/group_expense_service.go
+++ b/internal/service/group_expense_service.go
@@ -148,6 +148,9 @@ func (ges *groupExpenseServiceImpl) UpdateItem(ctx context.Context, request dto.
 	}
 
 	for _, participant := range request.Participants {
+		if participant.ProfileID == profileID {
+			continue // skip if participant is current user
+		}
 		// Check if the participant is a friend of the user
 		if isFriend, err := ges.friendshipService.IsFriends(ctx, profileID, participant.ProfileID); err != nil {
 			return dto.ExpenseItemResponse{}, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the current user was incorrectly included in friendship checks when updating group expense participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->